### PR TITLE
cmake: install header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,10 @@ target_link_libraries(stag_node
 # INSTALL #
 ###########
 
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+)
+
 install(FILES stag_nodelet.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
This patch was also part of upstream https://github.com/usrl-uofsc/stag_ros/pull/18. It is required to use the headers and library `stag_core` in downstream packages.