### PR TITLE
Fix mismatched new-delete pairs

### DIFF
--- a/src/stag/ED/ED.cpp
+++ b/src/stag/ED/ED.cpp
@@ -179,9 +179,9 @@ EdgeMap *DetectEdgesByEDPF(unsigned char *srcImg, int width, int height,
 #endif
 
   // Clean up
-  delete gradImg;
-  delete dirImg;
-  delete smoothImg;
+  delete[] gradImg;
+  delete[] dirImg;
+  delete[] smoothImg;
 
   return map;
 }  // DetectEdgesByEDPF

--- a/src/stag/ED/EDInternals.cpp
+++ b/src/stag/ED/EDInternals.cpp
@@ -188,7 +188,7 @@ static int *SortAnchorsByGradValue(short *gradImg, EdgeMap *map,
     }                            // end-for
   }                              // end-for
 
-  delete C;
+  delete[] C;
 
   *pNoAnchors = noAnchors;
   return A;
@@ -1450,10 +1450,10 @@ void JoinAnchorPointsUsingSortedAnchors(short *gradImg, unsigned char *dirImg,
   map->noSegments = noSegments;
 
   delete A;
-  delete chains;
-  delete stack;
-  delete pixels;
-  delete chainNos;
+  delete[] chains;
+  delete[] stack;
+  delete[] pixels;
+  delete[] chainNos;
 }  // end-JoinAnchorPointsUsingSortedAnchors
 
 ///-----------------------------------------------------------------------------------

--- a/src/stag/ED/EDLines.cpp
+++ b/src/stag/ED/EDLines.cpp
@@ -401,8 +401,8 @@ void ValidateLineSegments(EdgeMap *map, unsigned char *srcImg, EDLines *lines,
 
   delete LUT;
 
-  delete x;
-  delete y;
+  delete[] x;
+  delete[] y;
 
   // timer.Stop();
   lines->lineValidationTime = 1;  // timer.ElapsedTime();

--- a/src/stag/ED/ValidateEdgeSegments.cpp
+++ b/src/stag/ED/ValidateEdgeSegments.cpp
@@ -110,7 +110,7 @@ static short *ComputePrewitt3x3(unsigned char *srcImg, int width, int height,
   for (int i = 0; i < maxGradValue; i++)
     H[i] = (double)grads[i] / ((double)size);
 
-  delete grads;
+  delete[] grads;
   return gradImg;
 }  // end-ComputePrewitt3x3
 
@@ -408,8 +408,8 @@ void ValidateEdgeSegments(EdgeMap *map, unsigned char *srcImg,
   /// Extract the new edge segments after validation
   ExtractNewSegments(map);
 
-  delete H;
-  delete gradImg;
+  delete[] H;
+  delete[] gradImg;
 }  // end-ValidateEdgeSegments
 
 ///----------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes compiler warnings like:

```
stag_ros/src/stag/ED/ValidateEdgeSegments.cpp:113:3: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
  delete grads;
  ^
        []
```

This is a serious bug and results in memory leaks in the best case and undefined behavior or crashes in the worst according to [this source](https://stackoverflow.com/questions/9238731/how-serious-is-the-new-delete-operator-mismatch-error).